### PR TITLE
VBID-12819 Support go_rule when running skylark_docs

### DIFF
--- a/skydoc/rule_extractor.py
+++ b/skydoc/rule_extractor.py
@@ -39,6 +39,7 @@ SKYLARK_STUBS = {
     "repository_rule": skylark_globals.repository_rule,
     "rule": skylark_globals.rule,
     "load": skylark_globals.load,
+    "go_rule": skylark_globals.go_rule,
 }
 """Stubs for Skylark globals to be used to evaluate the .bzl file."""
 
@@ -66,9 +67,11 @@ def create_stubs(skylark_stubs, load_symbols):
   stubs = dict(skylark_stubs)
   for load_symbol in load_symbols:
     if load_symbol.alias:
-      stubs[load_symbol.alias] = ""
+      key = load_symbol.alias
     else:
-      stubs[load_symbol.symbol] = ""
+      key = load_symbol.symbol
+    if key not in stubs:
+      stubs[key] = ""
   return stubs
 
 

--- a/skydoc/stubs/skylark_globals.py
+++ b/skydoc/stubs/skylark_globals.py
@@ -41,6 +41,9 @@ def struct(**kwargs):
 def load(label, *args, **kwargs):
   return None
 
+def go_rule(label, **kwargs):
+  return None
+
 class Label(object):
   def __init__(self, label_string, relative_to_caller_repository=False):
     self.label_string = label_string


### PR DESCRIPTION
Give go_rule an empty python definition and make it so global definitions aren't
overwritten by bzl file definitions when loading stubs